### PR TITLE
HelperMappingBuilder.convertSourceValues tests

### DIFF
--- a/legend-engine-executionPlan-dependencies/pom.xml
+++ b/legend-engine-executionPlan-dependencies/pom.xml
@@ -79,5 +79,18 @@
         </dependency>
         <!-- OPEN JDK -->
         <!-- Dependencies needed to compile generaated code -->
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-executionPlan-execution-api/pom.xml
+++ b/legend-engine-executionPlan-execution-api/pom.xml
@@ -103,5 +103,18 @@
             <artifactId>eclipse-collections</artifactId>
         </dependency>
         <!-- ECLIPSE COLLECTIONS -->
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-executionPlan-execution-store-inMemory/pom.xml
+++ b/legend-engine-executionPlan-execution-store-inMemory/pom.xml
@@ -119,6 +119,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>

--- a/legend-engine-executionPlan-execution/pom.xml
+++ b/legend-engine-executionPlan-execution/pom.xml
@@ -172,6 +172,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-executionPlan-generation/pom.xml
+++ b/legend-engine-executionPlan-generation/pom.xml
@@ -105,6 +105,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-external-format-avro/pom.xml
+++ b/legend-engine-external-format-avro/pom.xml
@@ -143,6 +143,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <type>test-jar</type>

--- a/legend-engine-external-format-protobuf/pom.xml
+++ b/legend-engine-external-format-protobuf/pom.xml
@@ -139,6 +139,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <type>test-jar</type>

--- a/legend-engine-external-format-rosetta/pom.xml
+++ b/legend-engine-external-format-rosetta/pom.xml
@@ -135,6 +135,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-compiler</artifactId>
             <type>test-jar</type>

--- a/legend-engine-external-shared/pom.xml
+++ b/legend-engine-external-shared/pom.xml
@@ -98,5 +98,18 @@
             <artifactId>eclipse-collections</artifactId>
         </dependency>
         <!-- ECLIPSE COLLECTIONS -->
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-language-pure-compiler-api/pom.xml
+++ b/legend-engine-language-pure-compiler-api/pom.xml
@@ -120,6 +120,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
             <scope>test</scope>

--- a/legend-engine-language-pure-compiler/pom.xml
+++ b/legend-engine-language-pure-compiler/pom.xml
@@ -156,6 +156,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
             <scope>test</scope>

--- a/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperMappingBuilderDiffblueTest.java
+++ b/legend-engine-language-pure-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/HelperMappingBuilderDiffblueTest.java
@@ -1,0 +1,509 @@
+package org.finos.legend.engine.language.pure.compiler.toPureGraph;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.util.ArrayList;
+import java.util.HashMap;
+import org.eclipse.collections.api.list.MutableList;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.EnumValueMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.EnumValueMappingEnumSourceValue;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.EnumValueMappingIntegerSourceValue;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.EnumValueMappingStringSourceValue;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.EnumerationMapping;
+import org.finos.legend.pure.generated.Root_meta_pure_metamodel_type_Enum_Impl;
+import org.junit.Test;
+
+public class HelperMappingBuilderDiffblueTest {
+  @Test
+  public void testConvertSourceValues() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    // Act and Assert
+    assertTrue(HelperMappingBuilder
+        .convertSourceValues(enumerationMapping, new ArrayList<Object>(), mock(CompileContext.class))
+        .toList()
+        .isEmpty());
+  }
+
+  @Test
+  public void testConvertSourceValues10() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "STRING";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("42");
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues11() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = null;
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("42");
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues12() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "INTEGER";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("42");
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues13() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = null;
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("42");
+    objectList.add("42");
+
+    // Act and Assert
+    assertEquals(2,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues14() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "INTEGER";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("42");
+    objectList.add("42");
+
+    // Act and Assert
+    assertEquals(2,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues15() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("INTEGER");
+    CompileContext compileContext = mock(CompileContext.class);
+    when(compileContext.resolveEnumValue(anyString(), anyString()))
+        .thenReturn(new Root_meta_pure_metamodel_type_Enum_Impl("42"));
+
+    // Act and Assert
+    MutableList<?> toListResult = HelperMappingBuilder
+        .convertSourceValues(enumerationMapping, objectList, compileContext)
+        .toList();
+    assertEquals(1, toListResult.size());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._taggedValues.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._stereotypes.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0)).getCompileStates().toList().isEmpty());
+    verify(compileContext).resolveEnumValue(anyString(), anyString());
+  }
+
+  @Test
+  public void testConvertSourceValues16() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+    EnumValueMappingEnumSourceValue enumValueMappingEnumSourceValue = new EnumValueMappingEnumSourceValue();
+    enumValueMappingEnumSourceValue.enumeration = "STRING";
+    enumValueMappingEnumSourceValue.value = "42";
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add(enumValueMappingEnumSourceValue);
+    CompileContext compileContext = mock(CompileContext.class);
+    when(compileContext.resolveEnumValue(anyString(), anyString()))
+        .thenReturn(new Root_meta_pure_metamodel_type_Enum_Impl("42"));
+
+    // Act and Assert
+    MutableList<?> toListResult = HelperMappingBuilder
+        .convertSourceValues(enumerationMapping, objectList, compileContext)
+        .toList();
+    assertEquals(1, toListResult.size());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._taggedValues.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._stereotypes.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0)).getCompileStates().toList().isEmpty());
+    verify(compileContext).resolveEnumValue(anyString(), anyString());
+  }
+
+  @Test
+  public void testConvertSourceValues17() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+    EnumValueMappingIntegerSourceValue enumValueMappingIntegerSourceValue = new EnumValueMappingIntegerSourceValue();
+    enumValueMappingIntegerSourceValue.value = 42;
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add(enumValueMappingIntegerSourceValue);
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues18() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+    EnumValueMappingStringSourceValue enumValueMappingStringSourceValue = new EnumValueMappingStringSourceValue();
+    enumValueMappingStringSourceValue.value = "42";
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add(enumValueMappingStringSourceValue);
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues19() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = null;
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add(2);
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues2() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList arrayList = new ArrayList();
+    arrayList.add(new HashMap<Object, Object>());
+
+    // Act and Assert
+    assertThrows(UnsupportedOperationException.class,
+        () -> HelperMappingBuilder.convertSourceValues(enumerationMapping, arrayList, mock(CompileContext.class)));
+  }
+
+  @Test
+  public void testConvertSourceValues20() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "INTEGER";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add(2);
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues21() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "INTEGER";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add(null);
+
+    // Act and Assert
+    assertEquals(1,
+        HelperMappingBuilder.convertSourceValues(enumerationMapping, objectList, mock(CompileContext.class))
+            .toList()
+            .size());
+  }
+
+  @Test
+  public void testConvertSourceValues3() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    HashMap hashMap = new HashMap();
+    hashMap.put((Object) "fullPath", "foo");
+    hashMap.put((Object) "values", new ArrayList<Object>());
+    hashMap.put((Object) "_type", (Object) "string");
+    hashMap.put((Object) "value", "foo");
+
+    ArrayList arrayList = new ArrayList();
+    arrayList.add(hashMap);
+
+    // Act and Assert
+    assertTrue(HelperMappingBuilder.convertSourceValues(enumerationMapping, arrayList, mock(CompileContext.class))
+        .toList()
+        .isEmpty());
+  }
+
+  @Test
+  public void testConvertSourceValues4() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    HashMap hashMap = new HashMap();
+    hashMap.put((Object) "fullPath", "foo");
+    hashMap.put((Object) "values", new ArrayList<Object>());
+    hashMap.put((Object) "_type", (Object) "integer");
+    hashMap.put((Object) "value", "foo");
+
+    ArrayList arrayList = new ArrayList();
+    arrayList.add(hashMap);
+
+    // Act and Assert
+    assertTrue(HelperMappingBuilder.convertSourceValues(enumerationMapping, arrayList, mock(CompileContext.class))
+        .toList()
+        .isEmpty());
+  }
+
+  @Test
+  public void testConvertSourceValues5() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    HashMap hashMap = new HashMap();
+    hashMap.put((Object) "fullPath", "foo");
+    hashMap.put((Object) "values", new ArrayList<Object>());
+    hashMap.put((Object) "_type", (Object) "collection");
+    hashMap.put((Object) "value", "foo");
+
+    ArrayList arrayList = new ArrayList();
+    arrayList.add(hashMap);
+
+    // Act and Assert
+    assertTrue(HelperMappingBuilder.convertSourceValues(enumerationMapping, arrayList, mock(CompileContext.class))
+        .toList()
+        .isEmpty());
+  }
+
+  @Test
+  public void testConvertSourceValues6() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    HashMap hashMap = new HashMap();
+    hashMap.put((Object) "fullPath", "foo");
+    hashMap.put((Object) "values", new ArrayList<Object>());
+    hashMap.put((Object) "_type", "foo");
+    hashMap.put((Object) "value", "foo");
+
+    ArrayList arrayList = new ArrayList();
+    arrayList.add(hashMap);
+
+    // Act and Assert
+    assertThrows(UnsupportedOperationException.class,
+        () -> HelperMappingBuilder.convertSourceValues(enumerationMapping, arrayList, mock(CompileContext.class)));
+  }
+
+  @Test
+  public void testConvertSourceValues7() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    HashMap hashMap = new HashMap();
+    hashMap.put((Object) "fullPath", "foo");
+    hashMap.put((Object) "values", new ArrayList<Object>());
+    hashMap.put((Object) "_type", (Object) "enumValue");
+    hashMap.put((Object) "value", "foo");
+
+    ArrayList arrayList = new ArrayList();
+    arrayList.add(hashMap);
+    CompileContext compileContext = mock(CompileContext.class);
+    when(compileContext.resolveEnumValue(anyString(), anyString()))
+        .thenReturn(new Root_meta_pure_metamodel_type_Enum_Impl("42"));
+
+    // Act and Assert
+    MutableList<?> toListResult = HelperMappingBuilder
+        .convertSourceValues(enumerationMapping, arrayList, compileContext)
+        .toList();
+    assertEquals(1, toListResult.size());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._taggedValues.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._stereotypes.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0)).getCompileStates().toList().isEmpty());
+    verify(compileContext).resolveEnumValue(anyString(), anyString());
+  }
+
+  @Test
+  public void testConvertSourceValues8() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("42");
+    CompileContext compileContext = mock(CompileContext.class);
+    when(compileContext.resolveEnumValue(anyString(), anyString()))
+        .thenReturn(new Root_meta_pure_metamodel_type_Enum_Impl("42"));
+
+    // Act and Assert
+    MutableList<?> toListResult = HelperMappingBuilder
+        .convertSourceValues(enumerationMapping, objectList, compileContext)
+        .toList();
+    assertEquals(1, toListResult.size());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._taggedValues.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._stereotypes.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0)).getCompileStates().toList().isEmpty());
+    verify(compileContext).resolveEnumValue(anyString(), anyString());
+  }
+
+  @Test
+  public void testConvertSourceValues9() {
+    // Arrange
+    EnumerationMapping enumerationMapping = new EnumerationMapping();
+    enumerationMapping.id = "42";
+    enumerationMapping.enumeration = "Enumeration";
+    enumerationMapping.enumValueMappings = new ArrayList<EnumValueMapping>();
+    enumerationMapping.sourceType = "Source Type";
+    enumerationMapping.sourceInformation = new SourceInformation();
+
+    ArrayList<Object> objectList = new ArrayList<Object>();
+    objectList.add("42");
+    objectList.add("42");
+    CompileContext compileContext = mock(CompileContext.class);
+    when(compileContext.resolveEnumValue(anyString(), anyString()))
+        .thenReturn(new Root_meta_pure_metamodel_type_Enum_Impl("42"));
+
+    // Act and Assert
+    MutableList<?> toListResult = HelperMappingBuilder
+        .convertSourceValues(enumerationMapping, objectList, compileContext)
+        .toList();
+    assertEquals(2, toListResult.size());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._taggedValues.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0))._stereotypes.toList().isEmpty());
+    assertTrue(((Root_meta_pure_metamodel_type_Enum_Impl) toListResult.get(0)).getCompileStates().toList().isEmpty());
+    verify(compileContext, times(2)).resolveEnumValue(anyString(), anyString());
+  }
+}
+

--- a/legend-engine-language-pure-dsl-diagram/pom.xml
+++ b/legend-engine-language-pure-dsl-diagram/pom.xml
@@ -153,6 +153,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
             <type>test-jar</type>

--- a/legend-engine-language-pure-dsl-generation/pom.xml
+++ b/legend-engine-language-pure-dsl-generation/pom.xml
@@ -156,6 +156,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
             <type>test-jar</type>

--- a/legend-engine-language-pure-dsl-text/pom.xml
+++ b/legend-engine-language-pure-dsl-text/pom.xml
@@ -149,6 +149,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
             <type>test-jar</type>

--- a/legend-engine-language-pure-grammar-api/pom.xml
+++ b/legend-engine-language-pure-grammar-api/pom.xml
@@ -116,6 +116,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
             <scope>test</scope>

--- a/legend-engine-language-pure-grammar/pom.xml
+++ b/legend-engine-language-pure-grammar/pom.xml
@@ -162,6 +162,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-language-pure-modelManager-sdlc/pom.xml
+++ b/legend-engine-language-pure-modelManager-sdlc/pom.xml
@@ -119,5 +119,18 @@
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <!-- ANNOTATIONS -->
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-language-pure-modelManager/pom.xml
+++ b/legend-engine-language-pure-modelManager/pom.xml
@@ -95,6 +95,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
             <scope>test</scope>

--- a/legend-engine-protocol-pure/pom.xml
+++ b/legend-engine-protocol-pure/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-protocol/pom.xml
+++ b/legend-engine-protocol/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-query-pure/pom.xml
+++ b/legend-engine-query-pure/pom.xml
@@ -158,6 +158,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-server/pom.xml
+++ b/legend-engine-server/pom.xml
@@ -365,6 +365,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
     <profiles>

--- a/legend-engine-shared-core/pom.xml
+++ b/legend-engine-shared-core/pom.xml
@@ -147,6 +147,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>

--- a/legend-engine-shared-javaCompiler/pom.xml
+++ b/legend-engine-shared-javaCompiler/pom.xml
@@ -58,6 +58,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 
         <!-- Dependency versions -->
         <junit.version>4.13.1</junit.version>
+        <mockito.version>3.3.3</mockito.version>
         <eclipsecollections.version>10.2.0</eclipsecollections.version>
         <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
@@ -812,6 +813,14 @@
                 <version>${junit.version}</version>
             </dependency>
             <!-- JUNIT -->
+
+            <!-- MOCKITO -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+            </dependency>
+            <!-- MOCKITO -->
 
             <!-- ANTLR -->
             <dependency>


### PR DESCRIPTION
These [unit tests](https://github.com/Diffblue-benchmarks/legend-engine/pull/2/commits/93b06fa91da5dd3b76df320d3200de20558e2340) cover all the branches in `convertSourceValues` and the private methods called from it. 
The assertions will need further work.

Based on https://github.com/Diffblue-benchmarks/legend-engine/pull/1